### PR TITLE
Link directly to jshint options

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,11 @@ For more explanations of the lint errors JSHint will throw at you please visit [
 
 ### Options
 
-Any specified option will be passed through directly to [JSHint][], thus you can specify any option that JSHint supports. See the [JSHint documentation][] for a list of supported options.
+Any specified option will be passed through directly to [JSHint][], thus you can specify any option that JSHint supports. See the [JSHint options][] for a list of supported options.
 
 [JSHint]: http://www.jshint.com/
-[JSHint documentation]: http://www.jshint.com/docs/
+[JSHint options]: http://jshint.com/docs/options/
+
 
 A few additional options are supported:
 
@@ -46,6 +47,7 @@ Default: `null`
 
 A map of global variables, with keys as names and a boolean value to determine if they are assignable. This is not a standard JSHint option, but is passed into the `JSHINT` function as its third argument. See the [JSHint documentation][] for more information.
 
+[JSHint documentation]: http://www.jshint.com/docs/
 
 #### jshintrc
 


### PR DESCRIPTION
It took me a while to find them on the main jshint docs page
do I need CLA for docs improvments
